### PR TITLE
Fix unknown prop warnings

### DIFF
--- a/test/sandbox/src/examples/DragCategorical.svelte
+++ b/test/sandbox/src/examples/DragCategorical.svelte
@@ -3,7 +3,7 @@
 	import { Graphic, Grid, Section, PointLayer, Point } from '../../../../src/'
   import DataContainer from '@snlab/florence-datacontainer'
 
-	export let N = 100
+	const N = 100
 	let data = new DataContainer(generateData(N, 0.25))
 	function generateData (N, error) {
     const getError = () => -error + (Math.random() * (2 * error)) * N

--- a/test/sandbox/src/examples/Scatterplot.svelte
+++ b/test/sandbox/src/examples/Scatterplot.svelte
@@ -3,7 +3,7 @@
 	import { Graphic, Section, PointLayer, Point } from '../../../../src/'
   import DataContainer from '@snlab/florence-datacontainer'
 
-	export let N = 100
+	const N = 100
   let data = new DataContainer(generateData(N, 0.25))
 
 	function generateData (N, error) {


### PR DESCRIPTION
Currently in the sandbox examples for Scatterplot and DragCategorical there is a warning that `<Component> was created with unknown prop 'location'`.