### PR TITLE
Docs copy edit

### DIFF
--- a/site/src/routes/docs/concepts/interactivity.sveltex
+++ b/site/src/routes/docs/concepts/interactivity.sveltex
@@ -162,7 +162,7 @@ const name = ['West', 'North', 'East', 'South']
       x={a}
       y={b}
       radius={10}
-      fill={({ key }) => key === selectedKey ? 'red' : 'black' }
+      fill={key => key === selectedKey ? 'red' : 'black' }
       onMouseover={({ key }) => selectedKey = key}
       onMouseout={() => selectedKey = null}
     />

--- a/site/src/routes/docs/core/graphic.sveltex
+++ b/site/src/routes/docs/core/graphic.sveltex
@@ -45,7 +45,7 @@ Where `backgroundColor` is the area within the padded area, and `paddingColor` i
 | transformation | `String`: `'identity'` or `'polar'`        | no       | `'identity'` | -             |
 | flipX          | `Boolean`                                  | no       | `false`      | -             |
 | flipY          | `Boolean`                                  | no       | `false`      | -             |
-| padding        | `Number`, `Object`                         | no       | `undefnied`  | screen pixels |
+| padding        | `Number`, `Object`                         | no       | `undefined`  | screen pixels |
 | zoomIdentity   | `Object`                                   | no       | `undefined`  | -             |
 
 For more how to use these props, see the [local coordinates](/docs/concepts/local-coordinates) documentation.

--- a/site/src/routes/docs/marks/area.sveltex
+++ b/site/src/routes/docs/marks/area.sveltex
@@ -72,14 +72,14 @@ import HorizontalAreaLower from './utils/_HorizontalAreaLower.svelte'
 n.b. `independentAxis` defaults to 'x' when its value is undefined
 
 ### Other aesthetics
-| Prop           | Required | Types  | Default   | Description             | Unit(s)                    |
-| -------------- | -------- | ------ | --------- | ----------------------- | -------------------------- |
-| stroke         | false    | String | 'none'    | Stroke color            | Named color, hex, rgb, hsl |
-| stroke-width   | false    | Number | 0         | Stroke width            | Screen pixels              |
-| stroke-opacity | false    | Number | undefined | Stroke opacity          | Number between 0 and 1     |
-| fill           | false    | String | '#000000' | Fill color (under line) | Named color, hex, rgb, hsl |
-| fill-opacity   | false    | Number | undefined | Fill opacity            | Number between 0 and 1     |
-| opacity        | false    | Number | 1         | Mark opacity            | Number between 0 and 1     |
+| Prop          | Required | Types  | Default   | Description             | Unit(s)                    |
+| ------------- | -------- | ------ | --------- | ----------------------- | -------------------------- |
+| stroke        | false    | String | 'none'    | Stroke color            | Named color, hex, rgb, hsl |
+| strokeWidth   | false    | Number | 0         | Stroke width            | Screen pixels              |
+| strokeOpacity | false    | Number | undefined | Stroke opacity          | Number between 0 and 1     |
+| fill          | false    | String | '#000000' | Fill color (under line) | Named color, hex, rgb, hsl |
+| fillOpacity   | false    | Number | undefined | Fill opacity            | Number between 0 and 1     |
+| opacity       | false    | Number | 1         | Mark opacity            | Number between 0 and 1     |
 
 These are analogous to the CSS properties of the same names.
 

--- a/site/src/routes/docs/marks/label.sveltex
+++ b/site/src/routes/docs/marks/label.sveltex
@@ -55,20 +55,20 @@ To create plots with multiple labels, we can either loop over the dataset (with 
 | geometry | depends  | Object \| Function                   | undefined | GeoJSON object of type Point    | Data value to be scaled by Section's scaleX/scaleY. If Function then viewBox coordinates. |
 
 ### Other aesthetics
-| Prop           | Required | Types                | Default     | Description                           | Unit(s)                                                       |
-| -------------- | -------- | -------------------- | ----------- | ------------------------------------- | ------------------------------------------------------------- |
-| text           | false    | Number <br>\| String | undefined   | Text to display                       | NA                                                            |
-| font-size      | false    | Number               | 16          | Font size                             | Screen pixel                                                  |
-| font-weight    | false    | Number <br>\| String | 'normal'    | Font weight                           | Either a number between 0 and 1000, or 'normal', 'bold', etc. |
-| font-family    | false    | String               | 'Helvetica' | Font family                           | Name of font family                                           |
-| rotation       | false    | Number               | 0           | Degrees with which to rotate the mark | Degrees                                                       |
-| anchor-point   | false    | String               | 'center'    | Anchor point for x/y coordinate       | One of ['center', 'lb', 'lt', 'rt', 'rb', 'l', 'r', 't', 'b'] |
-| stroke         | false    | String               | 'none'      | Stroke color                          | Named color, hex, rgb, hsl                                    |
-| stroke-width   | false    | Number               | 0           | Stroke width                          | Screen pixel                                                  |
-| stroke-opacity | false    | Number               | undefined   | Stroke opacity                        | Number between 0 and 1                                        |
-| fill           | false    | String               | '#000000'   | Fill color                            | Named color, hex, rgb, hsl                                    |
-| fill-opacity   | false    | Number               | undefined   | Fill opacity                          | Number between 0 and 1                                        |
-| opacity        | false    | Number               | 1           | Mark opacity                          | Number between 0 and 1                                        |
+| Prop          | Required | Types                | Default     | Description                           | Unit(s)                                                       |
+| ------------- | -------- | -------------------- | ----------- | ------------------------------------- | ------------------------------------------------------------- |
+| text          | false    | Number <br>\| String | undefined   | Text to display                       | NA                                                            |
+| fontSize      | false    | Number               | 16          | Font size                             | Screen pixel                                                  |
+| fontWeight    | false    | Number <br>\| String | 'normal'    | Font weight                           | Either a number between 0 and 1000, or 'normal', 'bold', etc. |
+| fontFamily    | false    | String               | 'Helvetica' | Font family                           | Name of font family                                           |
+| rotation      | false    | Number               | 0           | Degrees with which to rotate the mark | Degrees                                                       |
+| anchorPoint   | false    | String               | 'center'    | Anchor point for x/y coordinate       | One of ['center', 'lb', 'lt', 'rt', 'rb', 'l', 'r', 't', 'b'] |
+| stroke        | false    | String               | 'none'      | Stroke color                          | Named color, hex, rgb, hsl                                    |
+| strokeWidth   | false    | Number               | 0           | Stroke width                          | Screen pixel                                                  |
+| strokeOpacity | false    | Number               | undefined   | Stroke opacity                        | Number between 0 and 1                                        |
+| fill          | false    | String               | '#000000'   | Fill color                            | Named color, hex, rgb, hsl                                    |
+| fillOpacity   | false    | Number               | undefined   | Fill opacity                          | Number between 0 and 1                                        |
+| opacity       | false    | Number               | 1           | Mark opacity                          | Number between 0 and 1                                        |
 
 These are analogous to the CSS properties of the same names.
 

--- a/site/src/routes/docs/marks/line.sveltex
+++ b/site/src/routes/docs/marks/line.sveltex
@@ -55,14 +55,14 @@ To create plots with multiple lines, we can either loop over the dataset (with `
 
 
 ### Other aesthetics
-| Prop           | Required | Types  | Default   | Description             | Unit(s)                    |
-| -------------- | -------- | ------ | --------- | ----------------------- | -------------------------- |
-| stroke         | false    | String | '#000000' | Stroke color            | Named color, hex, rgb, hsl |
-| stroke-width   | false    | Number | 3         | Stroke width            | Screen pixels              |
-| stroke-opacity | false    | Number | undefined | Stroke opacity          | Number between 0 and 1     |
-| fill           | false    | String | 'none'    | Fill color (under line) | Named color, hex, rgb, hsl |
-| fill-opacity   | false    | Number | undefined | Fill opacity            | Number between 0 and 1     |
-| opacity        | false    | Number | 1         | Mark opacity            | Number between 0 and 1     |
+| Prop          | Required | Types  | Default   | Description             | Unit(s)                    |
+| ------------- | -------- | ------ | --------- | ----------------------- | -------------------------- |
+| stroke        | false    | String | '#000000' | Stroke color            | Named color, hex, rgb, hsl |
+| strokeWidth   | false    | Number | 3         | Stroke width            | Screen pixels              |
+| strokeOpacity | false    | Number | undefined | Stroke opacity          | Number between 0 and 1     |
+| fill          | false    | String | 'none'    | Fill color (under line) | Named color, hex, rgb, hsl |
+| fillOpacity   | false    | Number | undefined | Fill opacity            | Number between 0 and 1     |
+| opacity       | false    | Number | 1         | Mark opacity            | Number between 0 and 1     |
 
 These are analogous to the CSS properties of the same names.
 

--- a/site/src/routes/docs/marks/point.sveltex
+++ b/site/src/routes/docs/marks/point.sveltex
@@ -54,15 +54,15 @@ To create plots with multiple points, we can either loop over the dataset (with 
 | geometry | depends  | Object \| Function                   | undefined | GeoJSON object of type Point    | Data value to be scaled by Section's scaleX/scaleY. If Function then viewBox coordinates. |
 
 ### Other aesthetics
-| Prop           | Required | Types  | Default   | Description    | Unit(s)                    |
-| -------------- | -------- | ------ | --------- | -------------- | -------------------------- |
-| radius         | false    | Number | 3         | Radius length  | Screen pixel               |
-| stroke         | false    | String | 'none'    | Stroke color   | Named color, hex, rgb, hsl |
-| stroke-width   | false    | Number | 0         | Stroke width   | Screen pixel               |
-| stroke-opacity | false    | Number | undefined | Stroke opacity | Number between 0 and 1     |
-| fill           | false    | String | '#000000' | Fill color     | Named color, hex, rgb, hsl |
-| fill-opacity   | false    | Number | undefined | Fill opacity   | Number between 0 and 1     |
-| opacity        | false    | Number | 1         | Mark opacity   | Number between 0 and 1     |
+| Prop          | Required | Types  | Default   | Description    | Unit(s)                    |
+| ------------- | -------- | ------ | --------- | -------------- | -------------------------- |
+| radius        | false    | Number | 3         | Radius length  | Screen pixel               |
+| stroke        | false    | String | 'none'    | Stroke color   | Named color, hex, rgb, hsl |
+| strokeWidth   | false    | Number | 0         | Stroke width   | Screen pixel               |
+| strokeOpacity | false    | Number | undefined | Stroke opacity | Number between 0 and 1     |
+| fill          | false    | String | '#000000' | Fill color     | Named color, hex, rgb, hsl |
+| fillOpacity   | false    | Number | undefined | Fill opacity   | Number between 0 and 1     |
+| opacity       | false    | Number | 1         | Mark opacity   | Number between 0 and 1     |
 
 These are analogous to the CSS properties of the same names.
 

--- a/site/src/routes/docs/marks/polygon.sveltex
+++ b/site/src/routes/docs/marks/polygon.sveltex
@@ -50,13 +50,13 @@ To create multiple polygons, we can either loop over the dataset (with `{#each}`
 
 ### Other aesthetics
 
-| Prop           | Required | Types  | Default   | Description                                                                                     | Unit(s)                    |
-| -------------- | -------- | ------ | --------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
-| stroke         | false    | String | 'none'    | Stroke color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke)           | Named color, hex, rgb, hsl |
-| stroke-width   | false    | Number | 0         | Stroke width [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width)     | Screen pixel               |
-| stroke-opacity | false    | Number | undefined | Stroke opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-opacity) | Number between 0 to 1      |
-| fill           | false    | String | '#000000' | Fill color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill)               | Named color, hex, rgb, hsl |
-| fill-opacity   | false    | Number | undefined | Fill opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-opacity)     | Number between 0 and 1     |
-| opacity        | false    | Number | 1         | Mark opacity  [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity)         | Number between 0 and 1     |
+| Prop          | Required | Types  | Default   | Description                                                                                     | Unit(s)                    |
+| ------------- | -------- | ------ | --------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
+| stroke        | false    | String | 'none'    | Stroke color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke)           | Named color, hex, rgb, hsl |
+| strokeWidth   | false    | Number | 0         | Stroke width [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width)     | Screen pixel               |
+| strokeOpacity | false    | Number | undefined | Stroke opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-opacity) | Number between 0 to 1      |
+| fill          | false    | String | '#000000' | Fill color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill)               | Named color, hex, rgb, hsl |
+| fillOpacity   | false    | Number | undefined | Fill opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-opacity)     | Number between 0 and 1     |
+| opacity       | false    | Number | 1         | Mark opacity  [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity)         | Number between 0 and 1     |
 
 These are analogous to the CSS properties of the same names.

--- a/site/src/routes/docs/marks/rectangle.sveltex
+++ b/site/src/routes/docs/marks/rectangle.sveltex
@@ -58,14 +58,14 @@ To create multiple rectangles, we can either loop over the dataset (with `{#each
 
 ### Other aesthetics
 
-| Prop           | Required | Types  | Default   | Description                                                                                     | Unit(s)                    |
-| -------------- | -------- | ------ | --------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
-| stroke         | false    | String | 'none'    | Stroke color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke)           | Named color, hex, rgb, hsl |
-| stroke-width   | false    | Number | 0         | Stroke width [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width)     | Screen pixel               |
-| stroke-opacity | false    | Number | undefined | Stroke opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-opacity) | Number between 0 to 1      |
-| fill           | false    | String | '#000000' | Fill color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill)               | Named color, hex, rgb, hsl |
-| fill-opacity   | false    | Number | undefined | Fill opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-opacity)     | Number between 0 and 1     |
-| opacity        | false    | Number | 1         | Mark opacity  [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity)         | Number between 0 and 1     |
+| Prop          | Required | Types  | Default   | Description                                                                                     | Unit(s)                    |
+| ------------- | -------- | ------ | --------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
+| stroke        | false    | String | 'none'    | Stroke color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke)           | Named color, hex, rgb, hsl |
+| strokeWidth   | false    | Number | 0         | Stroke width [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width)     | Screen pixel               |
+| strokeOpacity | false    | Number | undefined | Stroke opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-opacity) | Number between 0 to 1      |
+| fill          | false    | String | '#000000' | Fill color [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill)               | Named color, hex, rgb, hsl |
+| fillOpacity   | false    | Number | undefined | Fill opacity [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-opacity)     | Number between 0 and 1     |
+| opacity       | false    | Number | 1         | Mark opacity  [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity)         | Number between 0 and 1     |
 
 These are analogous to the CSS properties of the same names.
 

--- a/site/src/routes/docs/marks/symbol.sveltex
+++ b/site/src/routes/docs/marks/symbol.sveltex
@@ -58,16 +58,16 @@ To create multiple symbols, we can either loop over the dataset (with `{#each}`)
 | geometry | depends  | Object \| Function                   | undefined | GeoJSON object of type Point     | Data value to be scaled by Section's scaleX/scaleY. If Function then viewBox coordinates. |
 
 ### Other aesthetics
-| Prop           | Required | Types  | Default   | Description                   | Unit(s)                    |
-| -------------- | -------- | ------ | --------- | ----------------------------- | -------------------------- |
-| stroke         | false    | String | 'none'    | Stroke color                  | Named color, hex, rgb, hsl |
-| stroke-width   | false    | Number | 0         | Stroke width                  | Screen pixel               |
-| stroke-opacity | false    | Number | undefined | Stroke opacity                | Number between 0 and 1     |
-| fill           | false    | String | '#000000' | Fill color                    | Named color, hex, rgb, hsl |
-| fill-opacity   | false    | Number | undefined | Fill opacity                  | Number between 0 and 1     |
-| opacity        | false    | Number | 1         | Mark opacity                  | Number between 0 and 1     |
-| shape          | false    | String | 'circle'  | Shape of the symbol           |                            |
-| size           | false    | Number | 10        | Length and width of the symbol| Screen pixel               |
+| Prop          | Required | Types  | Default   | Description                    | Unit(s)                    |
+| ------------- | -------- | ------ | --------- | ------------------------------ | -------------------------- |
+| stroke        | false    | String | 'none'    | Stroke color                   | Named color, hex, rgb, hsl |
+| strokeWidth   | false    | Number | 0         | Stroke width                   | Screen pixel               |
+| strokeOpacity | false    | Number | undefined | Stroke opacity                 | Number between 0 and 1     |
+| fill          | false    | String | '#000000' | Fill color                     | Named color, hex, rgb, hsl |
+| fillOpacity   | false    | Number | undefined | Fill opacity                   | Number between 0 and 1     |
+| opacity       | false    | Number | 1         | Mark opacity                   | Number between 0 and 1     |
+| shape         | false    | String | 'circle'  | Shape of the symbol            |                            |
+| size          | false    | Number | 10        | Length and width of the symbol | Screen pixel               |
 
 These are mostly analogous to the CSS properties of the same names.
 


### PR DESCRIPTION
- converts kebab cased prop names to camel case
- removes destructuring from `key` exposed by fill prop in interactivity docs